### PR TITLE
Add conversation logging feature

### DIFF
--- a/ConversationLogger.cs
+++ b/ConversationLogger.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+
+namespace FAQChatbot
+{
+    public class ConversationLogger
+    {
+        private readonly string _filePath;
+
+        public ConversationLogger(string filePath)
+        {
+            _filePath = string.IsNullOrWhiteSpace(filePath) ? "conversation.log" : filePath;
+        }
+
+        public void Log(string question, string answer)
+        {
+            var entry = $"[{DateTime.UtcNow:O}] Q: {question}\nA: {answer}\n";
+            File.AppendAllText(_filePath, entry);
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.Extensions.Configuration;
+using System.IO;
 
 namespace FAQChatbot
 {
@@ -20,6 +21,8 @@ namespace FAQChatbot
             }
 
             var openAI = new OpenAIService(apiKey);
+            var logPath = config["Logging:ConversationFile"];
+            var logger = new ConversationLogger(logPath);
 
             Console.WriteLine("OpenAI FAQ Chatbot. Type your question (type 'exit' to quit):");
             while (true)
@@ -28,6 +31,7 @@ namespace FAQChatbot
                 if (question?.ToLower() == "exit") break;
                 var answer = openAI.Ask(question ?? "").GetAwaiter().GetResult();
                 Console.WriteLine("Bot: " + answer);
+                logger.Log(question ?? string.Empty, answer);
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ A C# console chatbot that uses the OpenAI API to answer questions.
 - Connects to OpenAI API (GPT-3/4)
 - Asks for API key at runtime (or set in appsettings.json)
 - Simple question/answer loop
+- Logs each conversation to `conversation.log`
 
 ## Setup
 1. `cd FAQChatbot`
 2. Install dependencies: `dotnet add package OpenAI`
 3. Set your OpenAI API key in `appsettings.json`
-4. `dotnet run`
+4. (Optional) Set `Logging:ConversationFile` in `appsettings.json` to change log location
+5. `dotnet run`
 
 ## Requirements
 - .NET 6 SDK

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,5 +1,8 @@
 {
   "OpenAI": {
     "ApiKey": "sk-..."
+  },
+  "Logging": {
+    "ConversationFile": "conversation.log"
   }
 }


### PR DESCRIPTION
## Summary
- add `ConversationLogger` class to log Q/A pairs
- log each exchange to a configurable file
- document logging feature and configuration

## Testing
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_687de29f2f688323a21d4513afd35dd3